### PR TITLE
Modal : Next.js Intercept Route를 통한 모달 관리

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,18 +9,19 @@
         "lint": "next lint"
     },
     "dependencies": {
+        "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "next": "15.4.6"
+        "zustand": "^5.0.7"
     },
     "devDependencies": {
-        "typescript": "^5",
+        "@eslint/eslintrc": "^3",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "tailwindcss": "^3.4.1",
         "eslint": "^9",
         "eslint-config-next": "15.4.6",
-        "@eslint/eslintrc": "^3"
+        "tailwindcss": "^3.4.1",
+        "typescript": "^5"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      zustand:
+        specifier: ^5.0.7
+        version: 5.0.7(@types/react@19.1.9)(react@19.1.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -1822,6 +1825,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.7:
+    resolution: {integrity: sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -3876,3 +3897,8 @@ snapshots:
   yaml@2.8.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.7(@types/react@19.1.9)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.1.9
+      react: 19.1.0

--- a/src/app/@modal/(.)photos/[id]/page.tsx
+++ b/src/app/@modal/(.)photos/[id]/page.tsx
@@ -1,0 +1,6 @@
+import { Modal } from '@/widgets/modal';
+
+export default async function PhotoModal({ params }: { params: Promise<{ id: string }> }) {
+    const photoId = (await params).id;
+    return <Modal id={photoId}>{photoId}</Modal>;
+}

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/default.tsx
+++ b/src/app/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+    return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,12 +14,18 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
     children,
+    modal,
 }: Readonly<{
     children: React.ReactNode;
+    modal: React.ReactNode;
 }>) {
     return (
         <html className={`h-screen min-h-screen leading-none ${chaney.variable}`} lang="ko">
-            <body className=" h-full w-full font-chaney">{children}</body>
+            <body className="h-full w-full font-chaney">
+                {children}
+                {modal}
+                <div id="modal-root" />
+            </body>
         </html>
     );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
-export default function Home() {
-    return <div>Hello World</div>;
+import { Home } from '@/views/home';
+
+export default function PhotoListPage() {
+    return <Home />;
 }

--- a/src/app/photos/[id]/page.tsx
+++ b/src/app/photos/[id]/page.tsx
@@ -1,0 +1,11 @@
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+    const slugs = ['1', '2', '3', '4', '5', '6'];
+    return slugs.map((slug) => ({ id: slug }));
+}
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+    const id = (await params).id;
+    return <div className="card">{id}</div>;
+}

--- a/src/views/home/index.ts
+++ b/src/views/home/index.ts
@@ -1,0 +1,1 @@
+export { Home } from './ui/Home';

--- a/src/views/home/ui/Home.tsx
+++ b/src/views/home/ui/Home.tsx
@@ -1,0 +1,7 @@
+import { ItemList } from '@/widgets/home';
+
+export function Home() {
+    const items = Array.from({ length: 6 }, (_, i) => i + 1);
+
+    return <ItemList items={items} />;
+}

--- a/src/widgets/home/index.ts
+++ b/src/widgets/home/index.ts
@@ -1,0 +1,1 @@
+export { ItemList } from './ui/ItemList';

--- a/src/widgets/home/ui/ItemList.tsx
+++ b/src/widgets/home/ui/ItemList.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { usePhotoStore } from '@/widgets/modal/model/store';
+import { useRouter } from 'next/navigation';
+
+export function ItemList({ items }: { items: number[] }) {
+    const router = useRouter();
+
+    const deleted = usePhotoStore((state) => state.deletedPhotos);
+    const visiblePhotos = items.filter((id) => !deleted.includes(id.toString()));
+
+    return (
+        <div className="w-full flex gap-2">
+            {visiblePhotos.map((id) => (
+                <div key={id} onClick={() => router.push(`/photos/${id}`)}>
+                    {id}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/widgets/modal/index.ts
+++ b/src/widgets/modal/index.ts
@@ -1,0 +1,1 @@
+export { Modal } from './ui/Modal';

--- a/src/widgets/modal/model/store.ts
+++ b/src/widgets/modal/model/store.ts
@@ -1,0 +1,15 @@
+// store.ts
+import { create } from 'zustand';
+
+type Store = {
+    deletedPhotos: string[];
+    deletePhoto: (id: string) => void;
+};
+
+export const usePhotoStore = create<Store>((set) => ({
+    deletedPhotos: [],
+    deletePhoto: (id) =>
+        set((state) => ({
+            deletedPhotos: [...state.deletedPhotos, id],
+        })),
+}));

--- a/src/widgets/modal/ui/Modal.tsx
+++ b/src/widgets/modal/ui/Modal.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { type ElementRef, useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { createPortal } from 'react-dom';
+import { usePhotoStore } from '../model/store';
+
+export function Modal({ children, id }: { children: React.ReactNode; id: string }) {
+    const router = useRouter();
+    const dialogRef = useRef<ElementRef<'dialog'>>(null);
+
+    useEffect(() => {
+        if (!dialogRef.current?.open) {
+            dialogRef.current?.showModal();
+        }
+    }, []);
+
+    function onDismiss() {
+        router.back();
+    }
+
+    function handleDelete() {
+        usePhotoStore.getState().deletePhoto(id);
+    }
+
+    return createPortal(
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+            onClick={onDismiss}
+        >
+            <dialog
+                ref={dialogRef}
+                className="relative w-full max-w-md rounded-lg bg-white p-6 shadow-lg backdrop:bg-black/50"
+                onClose={onDismiss}
+            >
+                <div className="flex justify-between">
+                    <button
+                        onClick={onDismiss}
+                        className="absolute right-4 top-4 text-gray-500 hover:text-gray-700"
+                        aria-label="Close modal"
+                    >
+                        ✕
+                    </button>
+                    {children}
+                    <button onClick={handleDelete} className="pr-5">
+                        해당 아이템 삭제하기
+                    </button>
+                </div>
+            </dialog>
+        </div>,
+        document.getElementById('modal-root')!
+    );
+}


### PR DESCRIPTION

### ✨ 작업 내용 (What)
Next.js Intercepting Routes(`@modal`)를 활용한 모달 라우트 구현
photos/[id] 상세 페이지 클릭 시 인터셉트된 모달 페이지 화면 구현
모달 내부에서 삭제 버튼 클릭 시 해당 사진 목록 제거 With Zustand
createPortal을 사용해 `#modal-root` DOM 노드에 모달 렌더링

### 💡 작업 이유 (Why)
페이지 전환 없이 모달 UI를 노출할 수 있는 Next.js 인터셉터 라우트 패턴 적용
photos/[id] 접근 시 SPA 내비게이션 경험 유지
전역 상태 관리(zustand)로 삭제 상태를 공유 (데이터베이스 사용하지 않고 리스트로 관리)

### 🛠 변경 사항 (Changes)
인터셉터 라우트를 활용한 PhotoModal 페이지 추가
dialog 태그 기반 모달 컴포넌트
삭제 시 zustand 상태 업데이트
아이템 클릭 시 router.push('/photos/[id]' -> 인터셉트 페이지로 이동)로 모달 열기
modal 슬롯 추가 (Intercepted Routes 렌더링 위치)
`#modal-root` DOM 노드 삽입

### ✅ 테스트 방법 (How to test)
pnpm run dev로 프로젝트 실행
/ 페이지 접속 → 1~6번 아이템 목록 확인
아이템 클릭 → /photos/[id] 모달 오픈
모달 내 "✕" 클릭 → 닫히고 원래 목록 유지
"해당 아이템 삭제하기" 클릭 → 모달 닫히고 해당 아이템 목록에서 제거

### [공식문서](https://nextjs.org/docs/app/api-reference/file-conventions/intercepting-routes)
